### PR TITLE
feat: allow overriding the default vite path

### DIFF
--- a/src/ViteAdapter.php
+++ b/src/ViteAdapter.php
@@ -131,7 +131,7 @@ class ViteAdapter
      */
     public function hotFile(): string
     {
-        return $this->config->uploadsPath . '/' . $this->config->hotFile;
+        return $this->config->viteDistPath . '/' . $this->config->hotFile;
     }
 
     /**
@@ -201,7 +201,9 @@ class ViteAdapter
      */
     private function reactRefresh(): array
     {
-        if ($this->config->useReact !== true) return [];
+        if ($this->config->useReact !== true) {
+            return [];
+        }
 
         return [sprintf(
             <<<'HTML'
@@ -391,7 +393,7 @@ class ViteAdapter
      */
     protected function manifestPath(string $buildDirectory): string
     {
-        return $this->config->uploadsPath . '/' . $buildDirectory . '/' . $this->manifestFilename;
+        return $this->config->viteDistPath . '/' . $buildDirectory . '/' . $this->manifestFilename;
     }
 
     /**
@@ -421,7 +423,9 @@ class ViteAdapter
      */
     protected function makeTagForChunk(string|null $src, string|null $url, array|null $chunk, array|null $manifest): string
     {
-        if (empty($url)) return "";
+        if (empty($url)) {
+            return "";
+        }
 
         if (
             (!isset($this->nonce) ||
@@ -567,7 +571,7 @@ class ViteAdapter
      */
     protected function assetPath(string $path, ?bool $secure = null): string
     {
-        return $this->config->uploadsUrl . '/' . $path;
+        return $this->config->viteDistUri . '/' . $path;
     }
 
     /**
@@ -575,7 +579,9 @@ class ViteAdapter
      */
     protected function makePreloadTagForChunk(string|null $src, string|null $url, array|null $chunk, array $manifest): string
     {
-        if (empty($url)) return "";
+        if (empty($url)) {
+            return "";
+        }
 
         $manifestHash = hash('md5', json_encode($manifest));
         $url .= "?ver=" . $manifestHash;

--- a/src/ViteConfig.php
+++ b/src/ViteConfig.php
@@ -4,8 +4,8 @@ namespace EvoMark\WpVite;
 
 class ViteConfig
 {
-    public string $uploadsPath = "";
-    public string $uploadsUrl = "";
+    public string $viteDistPath = "";
+    public string $viteDistUri = "";
     public string $hotFile;
     public array $dependencies;
     public string $namespace;
@@ -15,8 +15,8 @@ class ViteConfig
 
     public function __construct(array $configArray)
     {
-        $this->uploadsPath = $configArray['uploadsPath'];
-        $this->uploadsUrl = $configArray['uploadsUrl'];
+        $this->viteDistPath = $configArray['viteDistPath'];
+        $this->viteDistUri = $configArray['viteDistUri'];
         $this->hotFile = $configArray['hotFile'] ?? "hot";
         $this->dependencies = $configArray['dependencies'] ?? [];
         $this->namespace = $configArray['namespace'] ?? "";


### PR DESCRIPTION
The uploads directory might not work for some people, including me. When I deploy my wordpress apps, I'm using a zero-downtime deployment tool, and so it is very convenient that the dist directory is bundled **inside the theme**, for versioning.

The uploads are stored in a shared folder, **and is not versione**d (not bundled in git).

This commit allows user customisation, by adding filters in Wordpress. People can still use the default upload directory by not providing the filter.

{theme_root}/functions.php

```php
add_filter('vite_dist_path', fn ($distPath) => get_template_directory() . DIRECTORY_SEPARATOR . 'dist', 5, 1);
add_filter('vite_dist_uri', fn ($distPath) => get_template_directory_uri() . '/dist', 5, 1);
```

vite.config.js
```js
export default defineConfig({
  build: {
    outDir: './dist/theme-inertia/build',
    emptyOutDir: true
  },
  // ...
})
```


